### PR TITLE
Fix edge case when fetching remotes with unrelated incomplete history…

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -623,7 +623,11 @@ func getHaves(
 		}
 
 		err = getHavesFromRef(ref, remoteRefs, s, haves)
-		if err != nil {
+
+		// Take care of the edge case where iterating using Preorder over
+		// commits produces an `object not found` error, if using a shallow
+		// clone with incomplete history.
+		if err != nil && err != plumbing.ErrObjectNotFound {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
…. Fixes #1151

In getHaves, allow the getHavesRef to fail with Object Not found when iterating over incomplete history, and don't treat it as a fatal error.